### PR TITLE
fix exit status

### DIFF
--- a/bin/hetula-client
+++ b/bin/hetula-client
@@ -139,7 +139,7 @@ print "Login to organization '$args{organization}' succeeded\n";
 
 if ($args{action}) {
   my $ok = __doAction($args{action});
-  exit $ok ? 0 : 1;
+  exit($ok ? 0 : 1);
 }
 
 my $menu = {


### PR DESCRIPTION
`exit` has higher precedence than `?:`, so `exit $ok ? 0 : 1` parses as `(exit $ok) ? 0 : 1`, which is not what was intended.